### PR TITLE
Return swapped items in edit operations and improve client update

### DIFF
--- a/services/resource-service.js
+++ b/services/resource-service.js
@@ -116,6 +116,7 @@ async function swapIndexes(model, parentKey, parentUid, oldIndex, newIndex, t) {
     if (!other) return;
 
     await other.update({ index: oldIndex }, { transaction: t });
+    return other;
 }
 
 module.exports.getCoursesForUser = async (userUid) => {
@@ -188,14 +189,20 @@ module.exports.editCourseForUser = async ({ uid, name, oldIndex, newIndex, descr
 
     return sequelize.transaction(async (t) => {
         // perform swap
-        await swapIndexes(Course, "userUid", course.userUid, oldIndex, newIndex, t);
+        let otherCourse = await swapIndexes(Course, "userUid", course.userUid, oldIndex, newIndex, t);
 
         course.name = name.trim();
         course.index = newIndex;
         course.description = description;
         await course.save({ transaction: t });
 
-        return course.toJSON();
+        if (!otherCourse) {
+            return course;
+        }
+
+        let bothCourses = [course, otherCourse].map(c => c.toJSON());
+
+        return bothCourses;
     });
 };
 
@@ -204,14 +211,20 @@ module.exports.editSectionForUser = async ({ uid, name, oldIndex, newIndex, desc
     if (!section) throw new Error("Section not found");
 
     return sequelize.transaction(async (t) => {
-        await swapIndexes(Section, "courseUid", section.courseUid, oldIndex, newIndex, t);
+        let otherSection = await swapIndexes(Section, "courseUid", section.courseUid, oldIndex, newIndex, t);
 
         section.name = name.trim();
         section.index = newIndex;
         section.description = description;
         await section.save({ transaction: t });
 
-        return section.toJSON();
+        if (!otherSection) {
+            return section;
+        }
+
+        let bothSections = [section, otherSection].map(s => s.toJSON());
+
+        return bothSections;
     });
 };
 
@@ -220,14 +233,20 @@ module.exports.editUnitForUser = async ({ uid, name, oldIndex, newIndex, descrip
     if (!unit) throw new Error("Unit not found");
 
     return sequelize.transaction(async (t) => {
-        await swapIndexes(Unit, "sectionUid", unit.sectionUid, oldIndex, newIndex, t);
+        let otherUnit = await swapIndexes(Unit, "sectionUid", unit.sectionUid, oldIndex, newIndex, t);
 
         unit.name = name.trim();
         unit.index = newIndex;
         unit.description = description;
         await unit.save({ transaction: t });
 
-        return unit.toJSON();
+        if (!otherUnit) {
+            return unit;
+        }
+
+        let bothUnits = [unit, otherUnit].map(u => u.toJSON());
+
+        return bothUnits;
     });
 };
 
@@ -236,7 +255,7 @@ module.exports.editTaskForUser = async ({ uid, name, oldIndex, newIndex, descrip
     if (!task) throw new Error("Task not found");
 
     return sequelize.transaction(async (t) => {
-        await swapIndexes(Task, "unitUid", task.unitUid, oldIndex, newIndex, t);
+        let otherTask = await swapIndexes(Task, "unitUid", task.unitUid, oldIndex, newIndex, t);
 
         task.name = name.trim();
         task.index = newIndex;
@@ -244,7 +263,13 @@ module.exports.editTaskForUser = async ({ uid, name, oldIndex, newIndex, descrip
         task.genprompt = genprompt;
         await task.save({ transaction: t });
 
-        return task.toJSON();
+        if (!otherTask) { 
+            return task;
+        }
+
+        let bothTasks = [task, otherTask].map(t => t.toJSON());
+
+        return bothTasks;
     });
 };
 

--- a/static/client-js/editing-data.js
+++ b/static/client-js/editing-data.js
@@ -1,67 +1,92 @@
+function findParents(item, view) {
+  item.parentCourse = null;
+  item.parentSection = null;
+  item.parentUnit = null;
+
+  for (const course of window.ALL_COURSE_DATA) {
+
+    if (view === "sections" || view === "units" || view === "tasks") {
+      const section = course.sections?.find(s => s.uid === item.sectionUid || s.uid === item.uid);
+      if (section) {
+        item.parentCourse = course;
+        item.parentSection = section;
+      }
+    }
+
+    if (view === "units" || view === "tasks") {
+      const section = course.sections?.find(s => s.units.some(u => u.uid === item.uid));
+      if (section) {
+        item.parentCourse = course;
+        item.parentSection = section;
+
+        const unit = section.units.find(u => u.uid === item.uid);
+        if (unit) item.parentUnit = unit;
+      }
+    }
+
+    if (view === "tasks") {
+      for (const section of course.sections || []) {
+        for (const unit of section.units || []) {
+          const task = unit.tasks?.find(t => t.uid === item.uid);
+          if (task) {
+            item.parentCourse = course;
+            item.parentSection = section;
+            item.parentUnit = unit;
+          }
+        }
+      }
+    }
+
+    if (view === "courses" && course.uid === item.uid) {
+      item.parentCourse = course;
+    }
+  }
+
+  return item;
+}
+
 function updateRamAfterEdit(type, updatedItem) {
-  console.log('Updating RAM for', type, updatedItem);
+  const view = type + "s";
+  findParents(updatedItem, view);
+
+  const c = updatedItem.parentCourse;
+  const s = updatedItem.parentSection;
+  const u = updatedItem.parentUnit;
+
   if (!window.ALL_COURSE_DATA) return;
-
-  const findCourse = () =>
-    window.ALL_COURSE_DATA.find(c => c.uid === updatedItem.courseUid);
-
-  const findSection = (course) =>
-    course.sections.find(s => s.uid === updatedItem.sectionUid);
-
-  const findUnit = (section) =>
-    section.units.find(u => u.uid === updatedItem.unitUid);
 
   if (type === "course") {
     const course = window.ALL_COURSE_DATA.find(c => c.uid === updatedItem.uid);
     if (!course) return;
-
     Object.assign(course, updatedItem);
     window.ALL_COURSE_DATA.sort((a, b) => a.index - b.index);
     return;
   }
 
   if (type === "section") {
-    const course = findCourse();
-    if (!course) return;
-
-    const section = course.sections.find(s => s.uid === updatedItem.uid);
+    if (!c || !s) return console.error("Missing parentCourse or parentSection");
+    const section = c.sections.find(sec => sec.uid === updatedItem.uid);
     if (!section) return;
-
     Object.assign(section, updatedItem);
-    course.sections.sort((a, b) => a.index - b.index);
+    c.sections.sort((a, b) => a.index - b.index);
     return;
   }
 
   if (type === "unit") {
-    const course = findCourse();
-    if (!course) return;
-
-    const section = findSection(course);
-    if (!section) return;
-
-    const unit = section.units.find(u => u.uid === updatedItem.uid);
+    if (!c || !s) return console.error("Missing parents for unit");
+    const unit = s.units.find(un => un.uid === updatedItem.uid);
     if (!unit) return;
-
     Object.assign(unit, updatedItem);
-    section.units.sort((a, b) => a.index - b.index);
+    s.units.sort((a, b) => a.index - b.index);
     return;
   }
 
   if (type === "task") {
-    const course = findCourse();
-    if (!course) return;
-
-    const section = findSection(course);
-    if (!section) return;
-
-    const unit = findUnit(section);
-    if (!unit) return;
-
-    const task = unit.tasks.find(t => t.uid === updatedItem.uid);
+    if (!c || !s || !u) return console.error("Missing parents for task");
+    const task = u.tasks.find(t => t.uid === updatedItem.uid);
     if (!task) return;
-
     Object.assign(task, updatedItem);
-    unit.tasks.sort((a, b) => a.index - b.index);
+    u.tasks.sort((a, b) => a.index - b.index);
     return;
   }
 }
@@ -74,7 +99,7 @@ document.addEventListener('DOMContentLoaded', () => {
     const view = document.querySelector('.browser-tab.active')?.getAttribute('data-view') || 'courses';
 
     const items = window.getScoped(view);
-    const item = items.find(i => String(i.uid ?? i.id) === String(id));
+    const item = items.find(i => String(i.uid) === String(id));
     if (!item) return alert('Item not found.');
 
     const popup = document.createElement('div');
@@ -87,7 +112,7 @@ document.addEventListener('DOMContentLoaded', () => {
         <input type="text" id="name" value="${item.name || ''}" />
 
         <label>Index:</label>
-        <input type="number" id="index" value="${item.index || ''}" />
+        <input type="number" id="index" value="${item.index || 0}" />
 
         <label>Description:</label>
         <textarea id="description">${item.description || ''}</textarea>
@@ -107,9 +132,8 @@ document.addEventListener('DOMContentLoaded', () => {
       const newName = document.getElementById('name').value.trim();
       const newIndex = Number(document.getElementById('index').value);
       const newDescription = document.getElementById('description').value.trim();
-      const newGenPrompt = item.genprompt !== undefined
-        ? document.getElementById('genprompt').value.trim()
-        : undefined;
+      const newGenPrompt =
+        item.genprompt !== undefined ? document.getElementById('genprompt').value.trim() : undefined;
 
       const oldIndex = item.index;
 
@@ -119,7 +143,7 @@ document.addEventListener('DOMContentLoaded', () => {
           headers: { 'Content-Type': 'application/json' },
           body: JSON.stringify({
             type: view.slice(0, -1),
-            uid: item.uid ?? item.id,
+            uid: item.uid,
             name: newName,
             description: newDescription,
             genprompt: newGenPrompt,
@@ -129,25 +153,13 @@ document.addEventListener('DOMContentLoaded', () => {
         });
 
         const data = await response.json();
-        console.log('Edit response:', data);
-        console.log('hello', data.uid);
-        console.log('Type:', data.type);
         if (!data.success) throw new Error(data.error || 'Update failed');
 
-        // Update RAM
-        updateRamAfterEdit(data.type, {
-          uid: data.uid,
-          name: data.name,
-          description: data.description,
-          index: data.index,
-          sectionUid: data.sectionUid,
-          createdAt: data.createdAt,
-          updatedAt: data.updatedAt
-        });
+        // Extract objects with uid (0,1,2,...)
+        const updatedItems = Object.values(data).filter(v => v && typeof v === "object" && v.uid);
 
-        location.reload();
+        updatedItems.forEach(obj => updateRamAfterEdit(data.type, obj));
 
-        // Re-render UI
         if (typeof renderView === 'function') {
           renderView(view, document.getElementById('searchInput')?.value);
         }


### PR DESCRIPTION
Server-side edit functions now return both affected items when swapping indexes, allowing the client to update all relevant objects. The client-side editing logic was refactored to handle multiple updated items and improve parent lookup, ensuring in-memory data stays consistent after edits.